### PR TITLE
Create Windows registry key if it doesn't exist

### DIFF
--- a/manifest_windows.go
+++ b/manifest_windows.go
@@ -29,7 +29,9 @@ func (h *Host) Install() error {
 		return err
 	}
 
-	key, err := registry.OpenKey(registry.CURRENT_USER, registryName, registry.SET_VALUE)
+	// CreateKey creates a key named path under open key k. CreateKey returns the
+	// new key and a boolean flag that reports whether the key already existed.
+	key, _, err := registry.CreateKey(registry.CURRENT_USER, registryName, registry.SET_VALUE)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
OpenKey will not create a registry key if it doesn't already exist. Thus, the .Install() function fails on Windows, returning `The system cannot find the file specified.` unless the registry key already exists.